### PR TITLE
Update the procedure of resizing the image.

### DIFF
--- a/TextRecognitionDataGenerator/background_generator.py
+++ b/TextRecognitionDataGenerator/background_generator.py
@@ -63,8 +63,8 @@ def picture(height, width):
 
         if pic.size[0] < width:
             pic = pic.resize([width, int(pic.size[1] * (width / pic.size[0]))], Image.ANTIALIAS)
-        elif pic.size[1] < height:
-            pic.thumbnail([int(pic.size[0] * (height / pic.size[1])), height], Image.ANTIALIAS)
+        if pic.size[1] < height:
+            pic = pic.resize([int(pic.size[0] * (height / pic.size[1])), height], Image.ANTIALIAS)
 
         if (pic.size[0] == width):
             x = 0


### PR DESCRIPTION
Update the procedure of resizing the background image. 
1. It's possible for a really small background image that after resizing the width to the necessary text width, the height of the background image is still less than the necessary text height. Hence the `elif` is changed to `if`.
1. Also, `pic.resize` seems better than `pic.thumbnail` for resizing the small background image.