### PR TITLE
Add label to generator output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ generator = GeneratorFromStrings(
     random_blur=True
 )
 
-for img in generator:
+for img, lbl in generator:
     # Do something with the pillow images here.
 ```
 

--- a/tests.py
+++ b/tests.py
@@ -46,7 +46,7 @@ class Generators(unittest.TestCase):
         generator = GeneratorFromDict()
         i = 0
         while i < 100:
-            img = next(generator)
+            img, lbl = next(generator)
             self.assertTrue(img.size[1] == 32, "Shape is not right")
             i += 1
 
@@ -54,7 +54,7 @@ class Generators(unittest.TestCase):
         generator = GeneratorFromRandom()
         i = 0
         while i < 100:
-            img = next(generator)
+            img, lbl = next(generator)
             self.assertTrue(img.size[1] == 32, "Shape is not right")
             i += 1
 
@@ -62,7 +62,7 @@ class Generators(unittest.TestCase):
         generator = GeneratorFromStrings(["TEST TEST TEST"])
         i = 0
         while i < 100:
-            img = next(generator)
+            img, lbl = next(generator)
             self.assertTrue(img.size[1] == 32, "Shape is not right")
             i += 1
 
@@ -70,7 +70,7 @@ class Generators(unittest.TestCase):
         generator = GeneratorFromWikipedia()
         i = 0
         while i < 100:
-            img = next(generator)
+            img, lbl = next(generator)
             self.assertTrue(img.size[1] == 32, "Shape is not right")
             i += 1
 

--- a/trdg/generators/from_strings.py
+++ b/trdg/generators/from_strings.py
@@ -85,4 +85,4 @@ class GeneratorFromStrings:
             self.space_width,
             self.margins,
             self.fit,
-        )
+        ), self.strings[(self.generated_count - 1) % len(self.strings)]


### PR DESCRIPTION
Big oversight that made the helper Generators pretty close to useless as they were not returning the label with the generated image.

Fixed tests and code to return a tuple.