### PR TITLE
Use console_script for Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The path (`/output/path/`) must be absolute.
 ## New
 - Add `--character_spacing` to control space between characters (in pixels)
 - Add python module
-- Move `run.py` to an executable python file ([`trdg/bin/trdg`](trdg/bin/trdg))
 - Add `--font` to use only one font for all the generated images (Thank you @JulienCoutault!)
 - Add `--fit` and `--margins` for finer layout control
 - Change the text orientation using the `-or` parameter
@@ -174,7 +173,7 @@ If you want to add a new non-latin language, the amount of work is minimal.
 
 1. Create a new folder with your language [two-letters code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
 2. Add a .ttf font in it
-3. Edit `bin/trdg` to add an if statement in `load_fonts()`
+3. Edit `run.py` to add an if statement in `load_fonts()`
 4. Add a text file in `dicts` with the same two-letters code
 5. Run the tool as you normally would but add `-l` with your two-letters code
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="trdg",
-    version="1.3.1",
+    version="1.3.2",
     description="TextRecognitionDataGenerator: A synthetic data generator for text recognition",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -48,5 +48,9 @@ setup(
         "tqdm>=4.23.0",
         "beautifulsoup4>=4.6.0"
     ],
-    scripts=["trdg/bin/trdg"],
+    entry_points={
+        "console_scripts": [
+            "trdg=trdg.run:main"
+        ],
+    },
 )

--- a/tests.py
+++ b/tests.py
@@ -683,49 +683,49 @@ class DataGenerator(unittest.TestCase):
 
 class CommandLineInterface(unittest.TestCase):
     def test_output_dir(self):
-        args = ["run.py", "-c", "1", "--output_dir", "../tests/out_2/"]
+        args = ["python3", "run.py", "-c", "1", "--output_dir", "../tests/out_2/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out_2/")) == 1)
         empty_directory("tests/out_2/")
 
     def test_language_english(self):
-        args = ["run.py", "-l", "en", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-l", "en", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_french(self):
-        args = ["run.py", "-l", "fr", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-l", "fr", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_spanish(self):
-        args = ["run.py", "-l", "es", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-l", "es", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_german(self):
-        args = ["run.py", "-l", "de", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-l", "de", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_chinese(self):
-        args = ["run.py", "-l", "cn", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-l", "cn", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_count_parameter(self):
-        args = ["run.py", "-c", "10", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-c", "10", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 10)
         empty_directory("tests/out/")
 
     def test_random_sequences_letter_only(self):
-        args = ["run.py", "-rs", "-let", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-rs", "-let", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(
             all(
@@ -739,7 +739,7 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_random_sequences_number_only(self):
-        args = ["run.py", "-rs", "-num", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-rs", "-num", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(
             all(
@@ -753,7 +753,7 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_random_sequences_symbols_only(self):
-        args = ["run.py", "-rs", "-sym", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-rs", "-sym", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         with open("tests/out/labels.txt", "r") as f:
             self.assertTrue(
@@ -767,14 +767,14 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_handwritten(self):
-        args = ["run.py", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["python3", "run.py", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_personalfont(self):
         args = [
-            "run.py",
+            "python3", "run.py",
             "--font",
             "fonts/latin/Aller_Bd.ttf",
             "-c",
@@ -788,7 +788,7 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personalfont_unlocated(self):
         args = [
-            "run.py",
+            "python3", "run.py",
             "--font",
             "fonts/latin/unlocatedFont.ttf",
             "-c",

--- a/tests.py
+++ b/tests.py
@@ -683,49 +683,49 @@ class DataGenerator(unittest.TestCase):
 
 class CommandLineInterface(unittest.TestCase):
     def test_output_dir(self):
-        args = ["./bin/trdg", "-c", "1", "--output_dir", "../tests/out_2/"]
+        args = ["run.py", "-c", "1", "--output_dir", "../tests/out_2/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out_2/")) == 1)
         empty_directory("tests/out_2/")
 
     def test_language_english(self):
-        args = ["./bin/trdg", "-l", "en", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-l", "en", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_french(self):
-        args = ["./bin/trdg", "-l", "fr", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-l", "fr", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_spanish(self):
-        args = ["./bin/trdg", "-l", "es", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-l", "es", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_german(self):
-        args = ["./bin/trdg", "-l", "de", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-l", "de", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_chinese(self):
-        args = ["./bin/trdg", "-l", "cn", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-l", "cn", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_count_parameter(self):
-        args = ["./bin/trdg", "-c", "10", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-c", "10", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 10)
         empty_directory("tests/out/")
 
     def test_random_sequences_letter_only(self):
-        args = ["./bin/trdg", "-rs", "-let", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-rs", "-let", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(
             all(
@@ -739,7 +739,7 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_random_sequences_number_only(self):
-        args = ["./bin/trdg", "-rs", "-num", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-rs", "-num", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(
             all(
@@ -753,7 +753,7 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_random_sequences_symbols_only(self):
-        args = ["./bin/trdg", "-rs", "-sym", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-rs", "-sym", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         with open("tests/out/labels.txt", "r") as f:
             self.assertTrue(
@@ -767,14 +767,14 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_handwritten(self):
-        args = ["./bin/trdg", "-c", "1", "--output_dir", "../tests/out/"]
+        args = ["run.py", "-c", "1", "--output_dir", "../tests/out/"]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_personalfont(self):
         args = [
-            "./bin/trdg",
+            "run.py",
             "--font",
             "fonts/latin/Aller_Bd.ttf",
             "-c",
@@ -788,7 +788,7 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personalfont_unlocated(self):
         args = [
-            "./bin/trdg",
+            "run.py",
             "--font",
             "fonts/latin/unlocatedFont.ttf",
             "-c",

--- a/trdg/computer_text_generator.py
+++ b/trdg/computer_text_generator.py
@@ -3,7 +3,9 @@ import random as rnd
 from PIL import Image, ImageColor, ImageFont, ImageDraw, ImageFilter
 
 
-def generate(text, font, text_color, font_size, orientation, space_width, character_spacing, fit):
+def generate(
+    text, font, text_color, font_size, orientation, space_width, character_spacing, fit
+):
     if orientation == 0:
         return _generate_horizontal_text(
             text, font, text_color, font_size, space_width, character_spacing, fit
@@ -16,14 +18,14 @@ def generate(text, font, text_color, font_size, orientation, space_width, charac
         raise ValueError("Unknown orientation " + str(orientation))
 
 
-def _generate_horizontal_text(text, font, text_color, font_size, space_width, character_spacing, fit):
+def _generate_horizontal_text(
+    text, font, text_color, font_size, space_width, character_spacing, fit
+):
     image_font = ImageFont.truetype(font=font, size=font_size)
 
     space_width = int(image_font.getsize(" ")[0] * space_width)
 
-    char_widths = [
-        image_font.getsize(c)[0] if c != " " else space_width for c in text
-    ]
+    char_widths = [image_font.getsize(c)[0] if c != " " else space_width for c in text]
     text_width = sum(char_widths) + character_spacing * (len(text) - 1)
     text_height = max([image_font.getsize(c)[1] for c in text])
 
@@ -54,7 +56,9 @@ def _generate_horizontal_text(text, font, text_color, font_size, space_width, ch
         return txt_img
 
 
-def _generate_vertical_text(text, font, text_color, font_size, space_width, character_spacing, fit):
+def _generate_vertical_text(
+    text, font, text_color, font_size, space_width, character_spacing, fit
+):
     image_font = ImageFont.truetype(font=font, size=font_size)
 
     space_height = int(image_font.getsize(" ")[1] * space_width)
@@ -79,7 +83,12 @@ def _generate_vertical_text(text, font, text_color, font_size, space_width, char
     )
 
     for i, c in enumerate(text):
-        txt_draw.text((0, sum(char_heights[0:i]) + i * character_spacing), c, fill=fill, font=image_font)
+        txt_draw.text(
+            (0, sum(char_heights[0:i]) + i * character_spacing),
+            c,
+            fill=fill,
+            font=image_font,
+        )
 
     if fit:
         return txt_img.crop(txt_img.getbbox())

--- a/trdg/data_generator.py
+++ b/trdg/data_generator.py
@@ -3,11 +3,7 @@ import random as rnd
 
 from PIL import Image, ImageFilter
 
-from trdg import (
-    computer_text_generator,
-    background_generator,
-    distorsion_generator,
-)
+from trdg import computer_text_generator, background_generator, distorsion_generator
 
 try:
     from trdg import handwritten_text_generator
@@ -66,7 +62,14 @@ class FakeTextDataGenerator(object):
             image = handwritten_text_generator.generate(text, text_color)
         else:
             image = computer_text_generator.generate(
-                text, font, text_color, size, orientation, space_width, character_spacing, fit
+                text,
+                font,
+                text_color,
+                size,
+                orientation,
+                space_width,
+                character_spacing,
+                fit,
             )
 
         random_angle = rnd.randint(0 - skewing_angle, skewing_angle)

--- a/trdg/generators/__init__.py
+++ b/trdg/generators/__init__.py
@@ -1,6 +1,4 @@
 from trdg.generators.from_dict import GeneratorFromDict
 from trdg.generators.from_random import GeneratorFromRandom
 from trdg.generators.from_strings import GeneratorFromStrings
-from trdg.generators.from_wikipedia import (
-    GeneratorFromWikipedia,
-)
+from trdg.generators.from_wikipedia import GeneratorFromWikipedia

--- a/trdg/generators/from_strings.py
+++ b/trdg/generators/from_strings.py
@@ -63,29 +63,32 @@ class GeneratorFromStrings:
     def next(self):
         if self.generated_count == self.count:
             raise StopIteration
-        self.generated_count += 1        
-        return FakeTextDataGenerator.generate(
-            self.generated_count,
+        self.generated_count += 1
+        return (
+            FakeTextDataGenerator.generate(
+                self.generated_count,
+                self.strings[(self.generated_count - 1) % len(self.strings)],
+                self.fonts[(self.generated_count - 1) % len(self.fonts)],
+                None,
+                self.size,
+                None,
+                self.skewing_angle,
+                self.random_skew,
+                self.blur,
+                self.random_blur,
+                self.background_type,
+                self.distorsion_type,
+                self.distorsion_orientation,
+                self.is_handwritten,
+                0,
+                self.width,
+                self.alignment,
+                self.text_color,
+                self.orientation,
+                self.space_width,
+                self.character_spacing,
+                self.margins,
+                self.fit,
+            ),
             self.strings[(self.generated_count - 1) % len(self.strings)],
-            self.fonts[(self.generated_count - 1) % len(self.fonts)],
-            None,
-            self.size,
-            None,
-            self.skewing_angle,
-            self.random_skew,
-            self.blur,
-            self.random_blur,
-            self.background_type,
-            self.distorsion_type,
-            self.distorsion_orientation,
-            self.is_handwritten,
-            0,
-            self.width,
-            self.alignment,
-            self.text_color,
-            self.orientation,
-            self.space_width,
-            self.character_spacing,
-            self.margins,
-            self.fit,
-        ), self.strings[(self.generated_count - 1) % len(self.strings)]
+        )

--- a/trdg/run.py
+++ b/trdg/run.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import argparse
 import os, errno
 import random as rnd


### PR DESCRIPTION
#109 highlighted that the script installation was not working on Windows. The error was not identified because there are no tests on Windows.

Replaces `scripts` with `console_scripts`.

Fixes #109