### PR TITLE
Fix picture path, when using import

### DIFF
--- a/trdg/background_generator.py
+++ b/trdg/background_generator.py
@@ -59,11 +59,11 @@ def picture(height, width):
     """
         Create a background with a picture
     """
-
-    pictures = os.listdir("./pictures")
+    script_path = os.path.split(os.path.realpath(__file__))[0]
+    pictures = os.listdir(os.path.join(script_path, "pictures"))
 
     if len(pictures) > 0:
-        pic = Image.open("./pictures/" + pictures[rnd.randint(0, len(pictures) - 1)])
+        pic = Image.open(os.path.join(script_path, "pictures", pictures[rnd.randint(0, len(pictures) - 1)]))
 
         if pic.size[0] < width:
             pic = pic.resize(


### PR DESCRIPTION
Whatever use this repo by clone or pypi package, when background_type=3, it will raise FileNotFoundError: [Errno 2] No such file or directory: './pictures', because the path is not correct. We should get script path and join it.