### PR TITLE
Add argument dict

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -831,6 +831,34 @@ class CommandLineInterface(unittest.TestCase):
         self.assertTrue(len(os.listdir("tests/out/")) == 0)
         empty_directory("tests/out/")
 
+    def test_personaldict(self):
+        args = [
+            "python3", "run.py",
+            "--dict",
+            "dicts/en.txt",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
+        subprocess.Popen(args, cwd="trdg/").wait()
+        self.assertTrue(len(os.listdir("tests/out/")) == 1)
+        empty_directory("tests/out/")
+
+    def test_personaldict_unlocated(self):
+        args = [
+            "python3", "run.py",
+            "--dict",
+            "dicts/unlocatedDict.txt",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
+        subprocess.Popen(args, cwd="trdg/").wait()
+        self.assertTrue(len(os.listdir("tests/out/")) == 0)
+        empty_directory("tests/out/")
+
 #    def test_word_count(self):
 #        args = ['python3', 'run.py', '-c', '1', '-w', '5']
 #        subprocess.Popen(args, cwd="trdg/").wait()

--- a/trdg/run.py
+++ b/trdg/run.py
@@ -285,6 +285,9 @@ def parse_arguments():
         nargs="?",
         help="Generate upper or lowercase only. arguments: upper or lower. Example: --case upper",
     )
+    parser.add_argument(
+        "-dt", "--dict", type=str, nargs="?", help="Define dictionary to be used"
+    )
     return parser.parse_args()
 
 
@@ -304,7 +307,15 @@ def main():
             raise
 
     # Creating word list
-    lang_dict = load_dict(args.language)
+    if args.dict:
+        lang_dict = []
+        if os.path.isfile(args.dict):
+            with open(args.dict, "r", encoding="utf8", errors="ignore") as d:
+                lang_dict = [l for l in d.read().splitlines() if len(l) > 0]
+        else:
+            sys.exit("Cannot open dict")
+    else:
+        lang_dict = load_dict(args.language)
 
     # Create font (path) list
     if args.font_dir:


### PR DESCRIPTION
Now user can indicate what dictionary to use, by an argument like ```--dict [PATH_TO_DICT].txt```.
Related issue: #123 