### PR TITLE
Use diff instead of MD5 for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         "requests>=2.20.0",
         "opencv-python>=4.2.0.32",
         "tqdm>=4.23.0",
-        "beautifulsoup4>=4.6.0"
+        "beautifulsoup4>=4.6.0",
+        "diffimg==0.2.3",
     ],
     entry_points={
         "console_scripts": [

--- a/tests.py
+++ b/tests.py
@@ -151,8 +151,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_0.jpg",
                 "tests/expected_results/TEST TEST TEST_0.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_0.jpg")
@@ -189,8 +190,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_1.png",
                 "tests/expected_results/TEST TEST TEST_1.png",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_1.png")
@@ -227,8 +229,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_2.jpg",
                 "tests/expected_results/TEST TEST TEST_2.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_2.jpg")
@@ -265,8 +268,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_3.jpg",
                 "tests/expected_results/TEST TEST TEST_3.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_3.jpg")
@@ -303,8 +307,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_4.jpg",
                 "tests/expected_results/TEST TEST TEST_4.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_4.jpg")
@@ -341,8 +346,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_5.jpg",
                 "tests/expected_results/TEST TEST TEST_5.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_5.jpg")
@@ -379,8 +385,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_6.jpg",
                 "tests/expected_results/TEST TEST TEST_6.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_6.jpg")
@@ -417,8 +424,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_7.jpg",
                 "tests/expected_results/TEST TEST TEST_7.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_7.jpg")
@@ -455,8 +463,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_8.jpg",
                 "tests/expected_results/TEST TEST TEST_8.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_8.jpg")
@@ -525,8 +534,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_10.jpg",
                 "tests/expected_results/TEST TEST TEST_10.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_10.jpg")
@@ -563,8 +573,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_11.jpg",
                 "tests/expected_results/TEST TEST TEST_11.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_11.jpg")
@@ -601,8 +612,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_12.jpg",
                 "tests/expected_results/TEST TEST TEST_12.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_12.jpg")
@@ -671,8 +683,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/TEST TEST TEST_13.jpg",
                 "tests/expected_results/TEST TEST TEST_13.jpg",
-                delete_diff_file=True
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_13.jpg")
@@ -708,8 +721,9 @@ class DataGenerator(unittest.TestCase):
             diff(
                 "tests/out/white_background.jpg",
                 "tests/expected_results/white_background.jpg",
-                delete_diff_img=True,
-            ) < 0.01
+                delete_diff_file=True,
+            )
+            < 0.01
         )
 
         os.remove("tests/out/white_background.jpg")
@@ -728,31 +742,76 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out_2/")
 
     def test_language_english(self):
-        args = ["python3", "run.py", "-l", "en", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-l",
+            "en",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_french(self):
-        args = ["python3", "run.py", "-l", "fr", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-l",
+            "fr",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_spanish(self):
-        args = ["python3", "run.py", "-l", "es", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-l",
+            "es",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_german(self):
-        args = ["python3", "run.py", "-l", "de", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-l",
+            "de",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
 
     def test_language_chinese(self):
-        args = ["python3", "run.py", "-l", "cn", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-l",
+            "cn",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 1)
         empty_directory("tests/out/")
@@ -764,7 +823,16 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_random_sequences_letter_only(self):
-        args = ["python3", "run.py", "-rs", "-let", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-rs",
+            "-let",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(
             all(
@@ -778,7 +846,16 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_random_sequences_number_only(self):
-        args = ["python3", "run.py", "-rs", "-num", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-rs",
+            "-num",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(
             all(
@@ -792,7 +869,16 @@ class CommandLineInterface(unittest.TestCase):
         empty_directory("tests/out/")
 
     def test_random_sequences_symbols_only(self):
-        args = ["python3", "run.py", "-rs", "-sym", "-c", "1", "--output_dir", "../tests/out/"]
+        args = [
+            "python3",
+            "run.py",
+            "-rs",
+            "-sym",
+            "-c",
+            "1",
+            "--output_dir",
+            "../tests/out/",
+        ]
         subprocess.Popen(args, cwd="trdg/").wait()
         with open("tests/out/labels.txt", "r") as f:
             self.assertTrue(
@@ -813,7 +899,8 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personalfont(self):
         args = [
-            "python3", "run.py",
+            "python3",
+            "run.py",
             "--font",
             "fonts/latin/Aller_Bd.ttf",
             "-c",
@@ -827,7 +914,8 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personalfont_unlocated(self):
         args = [
-            "python3", "run.py",
+            "python3",
+            "run.py",
             "--font",
             "fonts/latin/unlocatedFont.ttf",
             "-c",
@@ -841,7 +929,8 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personalfont_directory(self):
         args = [
-            "python3", "run.py",
+            "python3",
+            "run.py",
             "--font_dir",
             "fonts/latin/",
             "-c",
@@ -855,7 +944,8 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personalfont_directory_unlocated(self):
         args = [
-            "python3", "run.py",
+            "python3",
+            "run.py",
             "--font_dir",
             "fonts/void/",
             "-c",
@@ -869,7 +959,8 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personaldict(self):
         args = [
-            "python3", "run.py",
+            "python3",
+            "run.py",
             "--dict",
             "dicts/en.txt",
             "-c",
@@ -883,7 +974,8 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_personaldict_unlocated(self):
         args = [
-            "python3", "run.py",
+            "python3",
+            "run.py",
             "--dict",
             "dicts/unlocatedDict.txt",
             "-c",
@@ -894,6 +986,7 @@ class CommandLineInterface(unittest.TestCase):
         subprocess.Popen(args, cwd="trdg/").wait()
         self.assertTrue(len(os.listdir("tests/out/")) == 0)
         empty_directory("tests/out/")
+
 
 #    def test_word_count(self):
 #        args = ['python3', 'run.py', '-c', '1', '-w', '5']

--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,8 @@ try:
 except:
     pass
 
+from diffimg import diff
+
 from trdg.data_generator import FakeTextDataGenerator
 from trdg import background_generator
 from trdg.generators import (
@@ -26,14 +28,6 @@ from trdg.string_generator import (
     create_strings_from_wikipedia,
     create_strings_randomly,
 )
-
-
-def md5(filename):
-    hash_md5 = hashlib.md5()
-    with open(filename, "rb") as f:
-        hash_md5.update(f.read())
-    h = hash_md5.hexdigest()
-    return h
 
 
 def empty_directory(path):
@@ -154,8 +148,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_0.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_0.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_0.jpg",
+                "tests/expected_results/TEST TEST TEST_0.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_0.jpg")
@@ -189,8 +186,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_1.png")
-            == md5("tests/expected_results/TEST TEST TEST_1.png")
+            diff(
+                "tests/out/TEST TEST TEST_1.png",
+                "tests/expected_results/TEST TEST TEST_1.png",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_1.png")
@@ -224,8 +224,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_2.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_2.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_2.jpg",
+                "tests/expected_results/TEST TEST TEST_2.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_2.jpg")
@@ -259,8 +262,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_3.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_3.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_3.jpg",
+                "tests/expected_results/TEST TEST TEST_3.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_3.jpg")
@@ -294,8 +300,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_4.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_4.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_4.jpg",
+                "tests/expected_results/TEST TEST TEST_4.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_4.jpg")
@@ -329,8 +338,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_5.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_5.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_5.jpg",
+                "tests/expected_results/TEST TEST TEST_5.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_5.jpg")
@@ -364,8 +376,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_6.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_6.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_6.jpg",
+                "tests/expected_results/TEST TEST TEST_6.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_6.jpg")
@@ -399,8 +414,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_7.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_7.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_7.jpg",
+                "tests/expected_results/TEST TEST TEST_7.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_7.jpg")
@@ -434,8 +452,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_8.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_8.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_8.jpg",
+                "tests/expected_results/TEST TEST TEST_8.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_8.jpg")
@@ -501,8 +522,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_10.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_10.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_10.jpg",
+                "tests/expected_results/TEST TEST TEST_10.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_10.jpg")
@@ -536,8 +560,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_11.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_11.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_11.jpg",
+                "tests/expected_results/TEST TEST TEST_11.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_11.jpg")
@@ -571,8 +598,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_12.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_12.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_12.jpg",
+                "tests/expected_results/TEST TEST TEST_12.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_12.jpg")
@@ -638,8 +668,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/TEST TEST TEST_13.jpg")
-            == md5("tests/expected_results/TEST TEST TEST_13.jpg")
+            diff(
+                "tests/out/TEST TEST TEST_13.jpg",
+                "tests/expected_results/TEST TEST TEST_13.jpg",
+                delete_diff_file=True
+            ) < 0.01
         )
 
         os.remove("tests/out/TEST TEST TEST_13.jpg")
@@ -672,8 +705,11 @@ class DataGenerator(unittest.TestCase):
         )
 
         self.assertTrue(
-            md5("tests/out/white_background.jpg")
-            == md5("tests/expected_results/white_background.jpg")
+            diff(
+                "tests/out/white_background.jpg",
+                "tests/expected_results/white_background.jpg",
+                delete_diff_img=True,
+            ) < 0.01
         )
 
         os.remove("tests/out/white_background.jpg")


### PR DESCRIPTION
Use MD5 for comparison was a pain because it would yield inconsistent results based on the systems PNG and JPEG libraries.

Using `diffimg` allows us to do a more forgiving matching, which will still trigger on different images while allowing some differences.