### PR TITLE
Fixed vertical text colouring bug

### DIFF
--- a/trdg/computer_text_generator.py
+++ b/trdg/computer_text_generator.py
@@ -94,7 +94,7 @@ def _generate_vertical_text(
     txt_mask = Image.new("RGBA", (text_width, text_height), (0, 0, 0, 0))
 
     txt_img_draw = ImageDraw.Draw(txt_img)
-    txt_mask_draw = ImageDraw.Draw(txt_img)
+    txt_mask_draw = ImageDraw.Draw(txt_mask)
 
     colors = [ImageColor.getrgb(c) for c in text_color.split(",")]
     c1, c2 = colors[0], colors[-1]


### PR DESCRIPTION
Generating vertical text images would always result in black text, even when a different text colour was specified.  I realized that the `ImageDraw.Draw` object used to draw on the mask image actually draws on the text image, so I adjusted it to draw on the mask image.

Fixes #132