### PR TITLE
Added whitespace bbox support and Tesseract format supported bboxes

### DIFF
--- a/trdg/data_generator.py
+++ b/trdg/data_generator.py
@@ -227,6 +227,8 @@ class FakeTextDataGenerator(object):
         image_name = "{}.{}".format(name, extension)
         mask_name = "{}_mask.png".format(name)
         box_name = "{}_boxes.txt".format(name)
+        tess_box_name = "{}.box".format(name)
+
 
         # Save the image
         if out_dir is not None:
@@ -238,6 +240,11 @@ class FakeTextDataGenerator(object):
                 with open(os.path.join(out_dir, box_name), "w") as f:
                     for bbox in bboxes:
                         f.write(" ".join([str(v) for v in bbox]) + "\n")
+            if output_bboxes == 2:
+                bboxes = mask_to_bboxes(final_mask)
+                with open(os.path.join(out_dir, tess_box_name), "w") as f:
+                    for bbox, char in zip(bboxes, text):
+                        f.write(" ".join([char] + [str(v) for v in bbox] + ['0']) + "\n")
         else:
             if output_mask == 1:
                 return final_image.convert("RGB"), final_mask.convert("RGB")

--- a/trdg/utils.py
+++ b/trdg/utils.py
@@ -47,10 +47,18 @@ def mask_to_bboxes(mask):
     bboxes = []
 
     i = 0
+    space_thresh = 1
     while True:
         try:
             color_tuple = ((i + 1) // (255 * 255), (i + 1) // 255, (i + 1) % 255)
             letter = np.where(np.all(mask_arr == color_tuple, axis=-1))
+            if space_thresh == 0 and letter:
+                x1 = bboxes[-1][0] + 1
+                y1 = bboxes[-1][1] + 1
+                x2 = np.max(letter[1])
+                y2 = np.max(letter[0])
+                bboxes.append((x1, y1, x2, y2))
+                space_thresh += 1
             bboxes.append((
                 max(0, np.min(letter[1]) - 1),
                 max(0, np.min(letter[0]) - 1),
@@ -59,7 +67,10 @@ def mask_to_bboxes(mask):
             ))
             i += 1
         except Exception as ex:
-            break
+            if space_thresh == 0:
+                break
+            space_thresh -= 1
+            i += 1
 
     return bboxes        
 


### PR DESCRIPTION
When generating strings containing whitespace characters only the characters of the first word would get bboxes, I fixed this (inside mask_to_bboxes under utils.py). 

Also, when passing 2 as the -obb argument, the bboxes are written in a <image>.box file in the format <symbol> <left> <bottom> <right> <top> <page> ready to train Tesseract.