### PR TITLE
Remove space in format 2 label when space width set to zero

### DIFF
--- a/trdg/run.py
+++ b/trdg/run.py
@@ -468,9 +468,10 @@ def main():
         ) as f:
             for i in range(string_count):
                 file_name = str(i) + "." + args.extension
+                label = strings[i]
                 if args.space_width == 0:
-                    file_name = file_name.replace(" ", "")
-                f.write("{} {}\n".format(file_name, strings[i]))
+                    label = label.replace(" ", "")
+                f.write("{} {}\n".format(file_name, label))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I guess the original commit "Remove space from label when space width is 0" was intended to do this. Let me know if I didn't get it right.