### PR TITLE
fix: conflicting dependencies error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pillow>=7.0.0
-numpy>=1.16.4,<1.17
 requests>=2.20.0
 opencv-python>=4.2.0.32
 tqdm>=4.23.0


### PR DESCRIPTION
numpy can be installed within openCV, no need to install it separately.
In addition, the specified range of versions for numpy is causing the following error (conflicting dependencies):

```
ERROR: Cannot install -r requirements.txt (line 4) and numpy<1.17 and >=1.16.4 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy<1.17 and >=1.16.4
    opencv-python 4.5.2.52 depends on numpy>=1.19.3
    The user requested numpy<1.17 and >=1.16.4
    opencv-python 4.5.1.48 depends on numpy>=1.19.3
    The user requested numpy<1.17 and >=1.16.4
    opencv-python 4.4.0.46 depends on numpy>=1.19.3
    The user requested numpy<1.17 and >=1.16.4
    opencv-python 4.4.0.44 depends on numpy>=1.17.3
    The user requested numpy<1.17 and >=1.16.4
    opencv-python 4.4.0.42 depends on numpy>=1.17.3
    The user requested numpy<1.17 and >=1.16.4
    opencv-python 4.4.0.40 depends on numpy>=1.17.3
    The user requested numpy<1.17 and >=1.16.4
    opencv-python 4.3.0.38 depends on numpy>=1.17.3
```