### PR TITLE
fix: Correct Bidi Arabic Text

### DIFF
--- a/trdg/run.py
+++ b/trdg/run.py
@@ -1,5 +1,6 @@
 import argparse
-import os, errno
+import errno
+import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
@@ -7,17 +8,16 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 import random as rnd
 import string
 import sys
+from multiprocessing import Pool
 
 from tqdm import tqdm
-from trdg.string_generator import (
-    create_strings_from_dict,
-    create_strings_from_file,
-    create_strings_from_wikipedia,
-    create_strings_randomly,
-)
-from trdg.utils import load_dict, load_fonts
+
 from trdg.data_generator import FakeTextDataGenerator
-from multiprocessing import Pool
+from trdg.string_generator import (create_strings_from_dict,
+                                   create_strings_from_file,
+                                   create_strings_from_wikipedia,
+                                   create_strings_randomly)
+from trdg.utils import load_dict, load_fonts
 
 
 def margins(margin):
@@ -407,10 +407,11 @@ def main():
 
     if args.language == "ar":
         from arabic_reshaper import ArabicReshaper
+        from bidi.algorithm import get_display
 
         arabic_reshaper = ArabicReshaper()
         strings = [
-            " ".join([arabic_reshaper.reshape(w) for w in s.split(" ")[::-1]])
+            " ".join([get_display(arabic_reshaper.reshape(w)) for w in s.split(" ")[::-1]])
             for s in strings
         ]
     if args.case == "upper":


### PR DESCRIPTION
Arabic is a right-left language so we need to write its text in that way and this PR fixes it.