### PR TITLE
support reshaping RTL strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ opencv-python>=4.2.0.32
 tqdm>=4.23.0
 beautifulsoup4>=4.6.0
 diffimg==0.2.3
+arabic-reshaper==2.1.3
+python-bidi==0.4.2

--- a/trdg/generators/from_strings.py
+++ b/trdg/generators/from_strings.py
@@ -49,8 +49,12 @@ class GeneratorFromStrings:
         if len(fonts) == 0:
             self.fonts = load_fonts(language)
         self.rtl = rtl
+        self.orig_strings = []
         if self.rtl:
             self.rtl_shaper = ArabicReshaper(configuration={"delete_harakat":False})
+            # save a backup of the original strings before arabic-reshaping
+            self.orig_strings = self.strings
+            # reshape the strings
             self.strings = self.reshape_rtl(self.strings, self.rtl_shaper)
         self.language = language
         self.size = size
@@ -120,7 +124,7 @@ class GeneratorFromStrings:
                 self.stroke_fill,
                 self.image_mode, 
             ),
-            self.strings[(self.generated_count - 1) % len(self.strings)],
+            self.orig_strings[(self.generated_count - 1) % len(self.orig_strings)] if self.rtl else self.strings[(self.generated_count - 1) % len(self.strings)],
         )
 
     def reshape_rtl(self, strings: list, rtl_shaper: ArabicReshaper):

--- a/trdg/generators/from_strings.py
+++ b/trdg/generators/from_strings.py
@@ -3,6 +3,9 @@ import os
 from ..data_generator import FakeTextDataGenerator
 from ..utils import load_dict, load_fonts
 
+# support RTL
+from arabic_reshaper import ArabicReshaper
+from bidi.algorithm import get_display
 
 class GeneratorFromStrings:
     """Generator that uses a given list of strings"""
@@ -13,6 +16,7 @@ class GeneratorFromStrings:
         count=-1,
         fonts=[],
         language="en",
+        rtl=False,
         size=32,
         skewing_angle=0,
         random_skew=False,
@@ -44,6 +48,10 @@ class GeneratorFromStrings:
         self.fonts = fonts
         if len(fonts) == 0:
             self.fonts = load_fonts(language)
+        self.rtl = rtl
+        if self.rtl:
+            self.rtl_shaper = ArabicReshaper(configuration={"delete_harakat":False})
+            self.strings = self.reshape_rtl(self.strings, self.rtl_shaper)
         self.language = language
         self.size = size
         self.skewing_angle = skewing_angle
@@ -114,3 +122,13 @@ class GeneratorFromStrings:
             ),
             self.strings[(self.generated_count - 1) % len(self.strings)],
         )
+
+    def reshape_rtl(self, strings: list, rtl_shaper: ArabicReshaper):
+        # reshape RTL characters before generating any image
+        rtl_strings = []
+        for string in strings:
+            reshaped_string = rtl_shaper.reshape(string)
+            rtl_strings.append(get_display(reshaped_string))
+        return rtl_strings
+
+


### PR DESCRIPTION
This pull request to support generating images containing Right-to-left strings (like in Arabic, Persian, Urdu, etc.)

-----

Th next script will generate an Image contains an Arabic (RTL) string. This's what the project is currently generating.

```python
from trdg.generators import GeneratorFromStrings

generator = GeneratorFromStrings(
    ['ذهبتُ إلى الشيخ زويد'],
    blur=1,
    size=128,
    random_blur=True,
    language="ar"
)

for img, lbl in generator:
    if img:
        img.save("without-rtl.png")
        break
```

The output will look like
![without-rtl](https://user-images.githubusercontent.com/14326057/146494125-0f039e4a-7dd0-4aa1-9603-0b38b8ab12c0.png)

-----

While, after this PR, the next code will able to generate a valid image with an RTL string

```python
from trdg.generators import GeneratorFromStrings

generator = GeneratorFromStrings(
    ['ذهبتُ إلى الشيخ زويد'],
    blur=1,
    size=128,
    random_blur=True,
    rtl=True, # Look HERE !!
    language="ar"
)

for img, lbl in generator:
    if img:
        img.save("with-rtl.png")
        break
```
The output will look like
![with-rtl](https://user-images.githubusercontent.com/14326057/146494305-e6722f25-cb71-4116-9647-fe25244ae26d.png)


