### PR TITLE
Allowing random blur to be decimal

### DIFF
--- a/trdg/data_generator.py
+++ b/trdg/data_generator.py
@@ -231,7 +231,7 @@ class FakeTextDataGenerator(object):
         #######################
 
         gaussian_filter = ImageFilter.GaussianBlur(
-            radius=blur if not random_blur else rnd.randint(0, blur)
+            radius=blur if not random_blur else rnd.random() * blur
         )
         final_image = background_img.filter(gaussian_filter)
         final_mask = background_mask.filter(gaussian_filter)


### PR DESCRIPTION
`PIL.ImageFilter.GaussianBlur` method allows decimal blur values, but using `random.randint` to generate a blur between 0 and the limit, will make the use of decimals generate an error, since you can't use an decimal in the randint method, and even if you could, it won't return decimal values. Then, the integer blur was always either too few or too agressive for TR. With this changes, it will be possible to find a number between these two extremes.

Note: It might have no effect since the radius is probably on pixel units, and this unit can't be decimal, but I didn't took the time to figure it out.