### PR TITLE
Fix Generator Performance for Large Amounts of Samples

### DIFF
--- a/trdg/generators/from_dict.py
+++ b/trdg/generators/from_dict.py
@@ -47,8 +47,16 @@ class GeneratorFromDict:
         self.length = length
         self.allow_variable = allow_variable
         self.dict = load_dict(language)
+
+        self.batch_size = min(max(count, 1), 1000)
+        self.steps_until_regeneration = self.batch_size
         self.generator = GeneratorFromStrings(
-            create_strings_from_dict(self.length, self.allow_variable, 1000, self.dict),
+            create_strings_from_dict(
+                self.length,
+                self.allow_variable,
+                self.batch_size,
+                self.dict
+            ),
             count,
             fonts if len(fonts) else load_fonts(language),
             language,
@@ -85,8 +93,12 @@ class GeneratorFromDict:
         return self.next()
 
     def next(self):
-        if self.generator.generated_count >= 999:
+        if self.generator.generated_count >= self.steps_until_regeneration:
             self.generator.strings = create_strings_from_dict(
-                self.length, self.allow_variable, 1000, self.dict
+                self.length,
+                self.allow_variable,
+                self.batch_size,
+                self.dict
             )
+            self.steps_until_regeneration += self.batch_size
         return self.generator.next()

--- a/trdg/generators/from_random.py
+++ b/trdg/generators/from_random.py
@@ -54,11 +54,14 @@ class GeneratorFromRandom:
         self.use_numbers = use_numbers
         self.use_symbols = use_symbols
         self.language = language
+
+        self.batch_size = min(max(count, 1), 1000)
+        self.steps_until_regeneration = self.batch_size
         self.generator = GeneratorFromStrings(
             create_strings_randomly(
                 self.length,
                 self.allow_variable,
-                1000,
+                self.batch_size,
                 self.use_letters,
                 self.use_numbers,
                 self.use_symbols,
@@ -103,14 +106,15 @@ class GeneratorFromRandom:
         return self.next()
 
     def next(self):
-        if self.generator.generated_count >= 999:
+        if self.generator.generated_count >= self.steps_until_regeneration:
             self.generator.strings = create_strings_randomly(
                 self.length,
                 self.allow_variable,
-                1000,
+                self.batch_size,
                 self.use_letters,
                 self.use_numbers,
                 self.use_symbols,
                 self.language,
             )
+            self.steps_until_regeneration += self.batch_size
         return self.generator.next()

--- a/trdg/generators/from_wikipedia.py
+++ b/trdg/generators/from_wikipedia.py
@@ -46,8 +46,11 @@ class GeneratorFromWikipedia:
         self.count = count
         self.minimum_length = minimum_length
         self.language = language
+
+        self.batch_size = min(max(count, 1), 1000)
+        self.steps_until_regeneration = self.batch_size
         self.generator = GeneratorFromStrings(
-            create_strings_from_wikipedia(self.minimum_length, 1000, self.language),
+            create_strings_from_wikipedia(self.minimum_length, self.batch_size, self.language),
             count,
             fonts if len(fonts) else load_fonts(language),
             language,
@@ -87,8 +90,11 @@ class GeneratorFromWikipedia:
         return self.next()
 
     def next(self):
-        if self.generator.generated_count >= 999:
+        if self.generator.generated_count >= self.steps_until_regeneration:
             self.generator.strings = create_strings_from_wikipedia(
-                self.minimum_length, 1000, self.language
+                self.minimum_length,
+                self.batch_size,
+                self.language
             )
+            self.steps_until_regeneration += self.batch_size
         return self.generator.next()


### PR DESCRIPTION
After generating more than 1000 images using a generator, 1000 more image were generated every step (instead of after an additional 1000 steps). This lead to a performance decrease, especially for the Wikipedia generator where generation of 1000 samples is especially costly. 

Also introduces the `batch_size` variable so that not too many samples are generated if count is much lower than the default (which was 1000). For reasons mentioned above, this is especially helpful for the Wikipedia generator.