### PR TITLE
fixed utf encoding issue

### DIFF
--- a/trdg/data_generator.py
+++ b/trdg/data_generator.py
@@ -274,12 +274,12 @@ class FakeTextDataGenerator(object):
                 final_mask.save(os.path.join(out_dir, mask_name))
             if output_bboxes == 1:
                 bboxes = mask_to_bboxes(final_mask)
-                with open(os.path.join(out_dir, box_name), "w") as f:
+                with open(os.path.join(out_dir, box_name), "w", encoding='utf8') as f:
                     for bbox in bboxes:
                         f.write(" ".join([str(v) for v in bbox]) + "\n")
             if output_bboxes == 2:
                 bboxes = mask_to_bboxes(final_mask, tess=True)
-                with open(os.path.join(out_dir, tess_box_name), "w") as f:
+                with open(os.path.join(out_dir, tess_box_name), "w", encoding='utf8') as f:
                     for bbox, char in zip(bboxes, text):
                         f.write(
                             " ".join([char] + [str(v) for v in bbox] + ["0"]) + "\n"


### PR DESCRIPTION
this fixes issue when generating data for other languages (like arabic)

reproduce issue with:

```sh
trdg --count 1000 \
    --length 10 \
    --format 64 \
    --output_dir trdg_data/ids \
    --language ar --font_dir TextRecognitionDataGenerator/trdg/fonts/ar/ \
    --skew_angle 15 --random_skew \
    --random \
    --thread_count 8 \
    --distorsion 3 --distorsion_orientation 2 \
    --background 2 \
    --random_blur \
    --output_bboxes 2
```

this is now fixed with the `encoding='utf8'` lines