### PR TITLE
bugfix: Solve the problem of text being cut off at the bottom #1

### DIFF
--- a/trdg/computer_text_generator.py
+++ b/trdg/computer_text_generator.py
@@ -104,7 +104,7 @@ def _generate_horizontal_text(
     if not word_split:
         text_width += character_spacing * (len(text) - 1)
 
-    text_height = max([get_text_height(image_font, p) for p in splitted_text])
+    text_height = max([get_text_height(image_font, p) for p in splitted_text]) * 2
 
     txt_img = Image.new("RGBA", (text_width, text_height), (0, 0, 0, 0))
     txt_mask = Image.new("RGB", (text_width, text_height), (0, 0, 0))


### PR DESCRIPTION
If the maximum value of all character heights is used as the text height, the text will be truncated in the final generated image. Here, 2 times the text height is used as the pre-generated image height to prevent the text area from being truncated.